### PR TITLE
[#27][common] fix : 공통모듈 설정 파일 오류 수정

### DIFF
--- a/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/common/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.newpick4u.common.config.AutoConfig


### PR DESCRIPTION
## Description
- 공통모듈 설정 파일의 경로가 src/main/resources/META-INF.spring 와 같이 설정되어 있어 스프링이 인식하지 못하는 
   오류가 발생함 
- > 파일의 경로를 src/main/resources/META-INF/spring으로 수정하였고 정상적으로 동작하는것을 확인하였음
Resolves: #27 

## PR Type
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
