### PR TITLE
[#52][news] 뉴스 추천 시스템 구현

### DIFF
--- a/news/build.gradle
+++ b/news/build.gradle
@@ -29,6 +29,7 @@ ext {
 
 dependencies {
 	implementation project(':common')
+	implementation 'org.redisson:redisson-spring-boot-starter:3.24.3'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'

--- a/news/build.gradle
+++ b/news/build.gradle
@@ -30,6 +30,8 @@ ext {
 dependencies {
 	implementation project(':common')
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'

--- a/news/build.gradle
+++ b/news/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.45.1'
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'

--- a/news/docker-compose.yml
+++ b/news/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper:latest
+    platform: linux/amd64
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+  kafka:
+    image: wurstmeister/kafka:latest
+    platform: linux/amd64
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:29092,OUTSIDE://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_LISTENERS: INSIDE://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    platform: linux/amd64
+    ports:
+      - "8080:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+      KAFKA_CLUSTERS_0_READONLY: "false"
+
+  redis-stack:
+    image: redis/redis-stack
+    container_name: redis-stack-auth
+    restart: always
+    environment:
+      REDIS_ARGS: "--requirepass systempass"
+    ports:
+      - 6379:6379
+      - 8001:8001

--- a/news/src/main/java/com/newpick4u/news/news/application/dto/NewsSearchCriteria.java
+++ b/news/src/main/java/com/newpick4u/news/news/application/dto/NewsSearchCriteria.java
@@ -1,4 +1,4 @@
-package com.newpick4u.news.news.domain.critria;
+package com.newpick4u.news.news.application.dto;
 
 public record NewsSearchCriteria(
         String keyword,

--- a/news/src/main/java/com/newpick4u/news/news/application/usecase/NewsRecommenderProvider.java
+++ b/news/src/main/java/com/newpick4u/news/news/application/usecase/NewsRecommenderProvider.java
@@ -1,0 +1,12 @@
+package com.newpick4u.news.news.application.usecase;
+
+import com.newpick4u.news.news.domain.entity.News;
+
+import java.util.List;
+
+public interface NewsRecommenderProvider {
+   List<News> recommendByContentVector( double[] userVector,
+                                        List<News> candidates,
+                                        List<String> tagIndexList
+   );
+}

--- a/news/src/main/java/com/newpick4u/news/news/application/usecase/NewsService.java
+++ b/news/src/main/java/com/newpick4u/news/news/application/usecase/NewsService.java
@@ -9,6 +9,7 @@ import com.newpick4u.news.news.application.dto.response.NewsSummaryDto;
 import com.newpick4u.news.news.application.dto.response.PageResponse;
 import com.newpick4u.news.news.domain.critria.NewsSearchCriteria;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface NewsService {
@@ -16,4 +17,5 @@ public interface NewsService {
     void updateNewsTagList(NewsTagDto dto);
     NewsResponseDto getNews(UUID id, CurrentUserInfoDto userInfo);
     PageResponse<NewsSummaryDto> searchNewsList(NewsSearchCriteria request, CurrentUserInfoDto userInfoDto);
+    List<NewsSummaryDto> recommendTop10(CurrentUserInfoDto user);
 }

--- a/news/src/main/java/com/newpick4u/news/news/application/usecase/NewsService.java
+++ b/news/src/main/java/com/newpick4u/news/news/application/usecase/NewsService.java
@@ -1,13 +1,12 @@
 package com.newpick4u.news.news.application.usecase;
 
-import com.newpick4u.common.resolver.annotation.CurrentUserInfo;
 import com.newpick4u.common.resolver.dto.CurrentUserInfoDto;
 import com.newpick4u.news.news.application.dto.NewsInfoDto;
 import com.newpick4u.news.news.application.dto.NewsTagDto;
 import com.newpick4u.news.news.application.dto.response.NewsResponseDto;
 import com.newpick4u.news.news.application.dto.response.NewsSummaryDto;
 import com.newpick4u.news.news.application.dto.response.PageResponse;
-import com.newpick4u.news.news.domain.critria.NewsSearchCriteria;
+import com.newpick4u.news.news.application.dto.NewsSearchCriteria;
 
 import java.util.List;
 import java.util.UUID;

--- a/news/src/main/java/com/newpick4u/news/news/application/usecase/NewsServiceImpl.java
+++ b/news/src/main/java/com/newpick4u/news/news/application/usecase/NewsServiceImpl.java
@@ -9,7 +9,7 @@ import com.newpick4u.news.news.application.dto.NewsTagDto;
 import com.newpick4u.news.news.application.dto.response.NewsResponseDto;
 import com.newpick4u.news.news.application.dto.response.NewsSummaryDto;
 import com.newpick4u.news.news.application.dto.response.PageResponse;
-import com.newpick4u.news.news.domain.critria.NewsSearchCriteria;
+import com.newpick4u.news.news.application.dto.NewsSearchCriteria;
 import com.newpick4u.news.news.domain.entity.News;
 import com.newpick4u.news.news.domain.entity.NewsTag;
 import com.newpick4u.news.news.domain.entity.TagInbox;

--- a/news/src/main/java/com/newpick4u/news/news/application/usecase/NewsServiceImpl.java
+++ b/news/src/main/java/com/newpick4u/news/news/application/usecase/NewsServiceImpl.java
@@ -61,7 +61,7 @@ public class NewsServiceImpl implements NewsService {
 
     // 내부 메서드
     private void validateTagListSize(NewsTagDto dto) {
-        if (dto.tagList() == null || dto.tagList().size() > 11) {
+        if (dto.tagList() == null || dto.tagList().size() > 10) {
             throw new IllegalArgumentException("뉴스 태그는 최대 10개까지 존재합니다.");
         }
     }

--- a/news/src/main/java/com/newpick4u/news/news/application/usecase/NewsServiceImpl.java
+++ b/news/src/main/java/com/newpick4u/news/news/application/usecase/NewsServiceImpl.java
@@ -16,6 +16,7 @@ import com.newpick4u.news.news.domain.entity.TagInbox;
 import com.newpick4u.news.news.domain.model.Pagination;
 import com.newpick4u.news.news.domain.repository.NewsRepository;
 import com.newpick4u.news.news.domain.repository.TagInboxRepository;
+import com.newpick4u.news.news.infrastructure.redis.UserTagRedisOperator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/news/src/main/java/com/newpick4u/news/news/application/usecase/TagLogRedisProvider.java
+++ b/news/src/main/java/com/newpick4u/news/news/application/usecase/TagLogRedisProvider.java
@@ -1,0 +1,13 @@
+package com.newpick4u.news.news.application.usecase;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public interface TagLogRedisProvider {
+    void incrementUserTags(Long userId, List<String> tags);
+    Map<String, Double> getUserTagScoreMap(Long userId);
+    List<String> getCachedRecommendedNews(Long userId);
+    void cacheRecommendedNews(Long userId, List<String> newsIds);
+    Set<Long> getAllUserIds();
+}

--- a/news/src/main/java/com/newpick4u/news/news/application/usecase/TagVectorConverterProvider.java
+++ b/news/src/main/java/com/newpick4u/news/news/application/usecase/TagVectorConverterProvider.java
@@ -1,0 +1,13 @@
+package com.newpick4u.news.news.application.usecase;
+
+import com.newpick4u.news.news.domain.entity.News;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public interface TagVectorConverterProvider {
+    Set<String> extractGlobalTagSetFromNews(Map<String, Double> userTagMap, List<News> newsList);
+    double[] toUserVector(Map<String, Double> tagScoreMap, List<String> tagIndexList);
+    double[] toNewsVector(News news, List<String> tagIndexList);
+}

--- a/news/src/main/java/com/newpick4u/news/news/application/usecase/UserRecommendationBatchService.java
+++ b/news/src/main/java/com/newpick4u/news/news/application/usecase/UserRecommendationBatchService.java
@@ -60,11 +60,7 @@ public class UserRecommendationBatchService {
                     .map(news -> news.getId().toString())
                     .collect(Collectors.toList());
 
-            String redisKey = "user:" + userId + ":recommend";
-            redisTemplate.delete(redisKey);
-            redisTemplate.opsForList().rightPushAll(redisKey, recommendedIds);
-            redisTemplate.expire(redisKey, Duration.ofDays(1));
-
+            userTagRedisOperator.cacheRecommendedNews(userId, recommendedIds);
             log.info("[추천 저장 완료] userId={}, count={}", userId, recommendedIds.size());
         } catch (Exception e) {
             log.error("[추천 저장 실패] userId={}", userId, e);

--- a/news/src/main/java/com/newpick4u/news/news/application/usecase/UserRecommendationBatchService.java
+++ b/news/src/main/java/com/newpick4u/news/news/application/usecase/UserRecommendationBatchService.java
@@ -1,0 +1,73 @@
+package com.newpick4u.news.news.application.usecase;
+
+import com.newpick4u.news.news.domain.entity.News;
+import com.newpick4u.news.news.domain.repository.NewsRepository;
+import com.newpick4u.news.news.infrastructure.redis.UserTagRedisOperator;
+import com.newpick4u.news.news.infrastructure.util.NewsRecommender;
+import com.newpick4u.news.news.infrastructure.util.TagVectorConverter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserRecommendationBatchService {
+
+    private final NewsRepository newsRepository;
+    private final UserTagRedisOperator userTagRedisOperator;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private final ExecutorService executorService = Executors.newFixedThreadPool(10); // ✅ 스레드 풀 사용
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void updateAllUserRecommendations() {
+        log.info("[배치 시작] 사용자 추천 뉴스 계산");
+
+        List<Long> userIds = new ArrayList<>(userTagRedisOperator.getAllUserIds());
+        List<News> allNews = newsRepository.findAllActive();
+
+        for (Long userId : userIds) {
+            executorService.submit(() -> updateSingleUserRecommendation(userId, allNews));
+        }
+    }
+
+    private void updateSingleUserRecommendation(Long userId, List<News> allNews) {
+        try {
+            Map<String, Double> userTagMap = userTagRedisOperator.getUserTagScoreMap(userId);
+            if (userTagMap.isEmpty()) return;
+
+            Set<String> globalTagSet = TagVectorConverter.extractGlobalTagSetFromNews(userTagMap, allNews);
+            List<String> tagIndexList = new ArrayList<>(globalTagSet);
+            // 1. 벡터화
+            double[] userVector = TagVectorConverter.toUserVector(userTagMap, tagIndexList);
+
+            // 2. 유사도 계산
+            List<News> recommended = NewsRecommender.recommendByContentVector(userVector, allNews, tagIndexList);
+
+            // 3. Redis에 캐싱
+            List<String> recommendedIds = recommended.stream()
+                    .map(news -> news.getId().toString())
+                    .collect(Collectors.toList());
+
+            String redisKey = "user:" + userId + ":recommend";
+            redisTemplate.delete(redisKey);
+            redisTemplate.opsForList().rightPushAll(redisKey, recommendedIds);
+            redisTemplate.expire(redisKey, Duration.ofDays(1));
+
+            log.info("[추천 저장 완료] userId={}, count={}", userId, recommendedIds.size());
+        } catch (Exception e) {
+            log.error("[추천 저장 실패] userId={}", userId, e);
+        }
+    }
+}

--- a/news/src/main/java/com/newpick4u/news/news/application/usecase/UserRecommendationBatchService.java
+++ b/news/src/main/java/com/newpick4u/news/news/application/usecase/UserRecommendationBatchService.java
@@ -2,19 +2,12 @@ package com.newpick4u.news.news.application.usecase;
 
 import com.newpick4u.news.news.domain.entity.News;
 import com.newpick4u.news.news.domain.repository.NewsRepository;
-import com.newpick4u.news.news.infrastructure.redis.UserTagRedisOperator;
-import com.newpick4u.news.news.infrastructure.util.NewsRecommender;
-import com.newpick4u.news.news.infrastructure.util.TagVectorConverter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -25,16 +18,16 @@ import java.util.stream.Collectors;
 public class UserRecommendationBatchService {
 
     private final NewsRepository newsRepository;
-    private final UserTagRedisOperator userTagRedisOperator;
-    private final RedisTemplate<String, String> redisTemplate;
-
-    private final ExecutorService executorService = Executors.newFixedThreadPool(10); // ✅ 스레드 풀 사용
+    private final TagLogRedisProvider tagLogRedisProvider;
+    private final TagVectorConverterProvider tagVectorConverterProvider;
+    private final NewsRecommenderProvider newsRecommenderProvider;
+    private final ExecutorService executorService = Executors.newFixedThreadPool(10);
 
     @Scheduled(cron = "0 0 3 * * *")
     public void updateAllUserRecommendations() {
         log.info("[배치 시작] 사용자 추천 뉴스 계산");
 
-        List<Long> userIds = new ArrayList<>(userTagRedisOperator.getAllUserIds());
+        List<Long> userIds = new ArrayList<>(tagLogRedisProvider.getAllUserIds());
         List<News> allNews = newsRepository.findAllActive();
 
         for (Long userId : userIds) {
@@ -44,23 +37,23 @@ public class UserRecommendationBatchService {
 
     private void updateSingleUserRecommendation(Long userId, List<News> allNews) {
         try {
-            Map<String, Double> userTagMap = userTagRedisOperator.getUserTagScoreMap(userId);
+            Map<String, Double> userTagMap = tagLogRedisProvider.getUserTagScoreMap(userId);
             if (userTagMap.isEmpty()) return;
 
-            Set<String> globalTagSet = TagVectorConverter.extractGlobalTagSetFromNews(userTagMap, allNews);
+            Set<String> globalTagSet = tagVectorConverterProvider.extractGlobalTagSetFromNews(userTagMap, allNews);
             List<String> tagIndexList = new ArrayList<>(globalTagSet);
             // 1. 벡터화
-            double[] userVector = TagVectorConverter.toUserVector(userTagMap, tagIndexList);
+            double[] userVector = tagVectorConverterProvider.toUserVector(userTagMap, tagIndexList);
 
             // 2. 유사도 계산
-            List<News> recommended = NewsRecommender.recommendByContentVector(userVector, allNews, tagIndexList);
+            List<News> recommended = newsRecommenderProvider.recommendByContentVector(userVector, allNews, tagIndexList);
 
             // 3. Redis에 캐싱
             List<String> recommendedIds = recommended.stream()
                     .map(news -> news.getId().toString())
                     .collect(Collectors.toList());
 
-            userTagRedisOperator.cacheRecommendedNews(userId, recommendedIds);
+            tagLogRedisProvider.cacheRecommendedNews(userId, recommendedIds);
             log.info("[추천 저장 완료] userId={}, count={}", userId, recommendedIds.size());
         } catch (Exception e) {
             log.error("[추천 저장 실패] userId={}", userId, e);

--- a/news/src/main/java/com/newpick4u/news/news/docker-compose.yml
+++ b/news/src/main/java/com/newpick4u/news/news/docker-compose.yml
@@ -32,3 +32,13 @@ services:
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
       KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
       KAFKA_CLUSTERS_0_READONLY: "false"
+
+  redis-stack:
+    image: redis/redis-stack
+    container_name: redis-stack-auth
+    restart: always
+    environment:
+      REDIS_ARGS: "--requirepass systempass"
+    ports:
+      - 6379:6379
+      - 8001:8001

--- a/news/src/main/java/com/newpick4u/news/news/domain/entity/News.java
+++ b/news/src/main/java/com/newpick4u/news/news/domain/entity/News.java
@@ -4,6 +4,8 @@ import com.newpick4u.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.BatchSize;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -42,7 +44,7 @@ public class News extends BaseEntity {
 
     @OneToMany(mappedBy = "news", cascade = CascadeType.ALL, orphanRemoval = true)
     @BatchSize(size = 10)
-    private List<NewsTag> newsTagList;
+    private List<NewsTag> newsTagList = new ArrayList<>(); ;
 
     @Builder(access = AccessLevel.PRIVATE)
     private News(String aiNewsId, String title, String content,String url, String publishedDate, Long view, NewsStatus status) {

--- a/news/src/main/java/com/newpick4u/news/news/domain/entity/News.java
+++ b/news/src/main/java/com/newpick4u/news/news/domain/entity/News.java
@@ -26,10 +26,10 @@ public class News extends BaseEntity {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    @Column(nullable = false)
+    @Column(nullable = false,  columnDefinition = "TEXT")
     private String url;
 
     @Column(nullable = false)

--- a/news/src/main/java/com/newpick4u/news/news/domain/repository/NewsRepository.java
+++ b/news/src/main/java/com/newpick4u/news/news/domain/repository/NewsRepository.java
@@ -19,4 +19,8 @@ public interface NewsRepository  {
     List<News> findAllActive();
     List<News> findLatestNews(int limit);
     List<News> findByIds(List<UUID> ids);
+    List<News> saveAll(List<News> newsList);
+    void deleteAll();
+    Optional<News> findById(UUID id);
+
 }

--- a/news/src/main/java/com/newpick4u/news/news/domain/repository/NewsRepository.java
+++ b/news/src/main/java/com/newpick4u/news/news/domain/repository/NewsRepository.java
@@ -1,6 +1,6 @@
 package com.newpick4u.news.news.domain.repository;
 
-import com.newpick4u.news.news.domain.critria.NewsSearchCriteria;
+import com.newpick4u.news.news.application.dto.NewsSearchCriteria;
 import com.newpick4u.news.news.domain.entity.News;
 import com.newpick4u.news.news.domain.model.Pagination;
 

--- a/news/src/main/java/com/newpick4u/news/news/domain/repository/NewsRepository.java
+++ b/news/src/main/java/com/newpick4u/news/news/domain/repository/NewsRepository.java
@@ -3,6 +3,8 @@ package com.newpick4u.news.news.domain.repository;
 import com.newpick4u.news.news.domain.critria.NewsSearchCriteria;
 import com.newpick4u.news.news.domain.entity.News;
 import com.newpick4u.news.news.domain.model.Pagination;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -14,4 +16,7 @@ public interface NewsRepository  {
     Pagination<News> searchNewsList(NewsSearchCriteria request, boolean isMaster);
     Optional<News> findNewsByRole(UUID id, boolean isMaster);
     void flush();
+    List<News> findAllActive();
+    List<News> findLatestNews(int limit);
+    List<News> findByIds(List<UUID> ids);
 }

--- a/news/src/main/java/com/newpick4u/news/news/domain/repository/NewsRepositoryCustom.java
+++ b/news/src/main/java/com/newpick4u/news/news/domain/repository/NewsRepositoryCustom.java
@@ -10,10 +10,16 @@ import java.util.UUID;
 
 public interface NewsRepositoryCustom {
     Pagination<News> searchNewsList(NewsSearchCriteria request, boolean isMaster);
+
     Optional<News> findNewsByRole(UUID id, boolean isMaster);
+
     Optional<News> findWithTagsByAiNewsId(String aiNewsId);
+
     List<News> findAllActive();
+
     List<News> findLatestNews(int limit);
+
     List<News> findByIds(List<UUID> ids);
 
+    Optional<News> findWithTagsById(UUID id);
 }

--- a/news/src/main/java/com/newpick4u/news/news/domain/repository/NewsRepositoryCustom.java
+++ b/news/src/main/java/com/newpick4u/news/news/domain/repository/NewsRepositoryCustom.java
@@ -3,6 +3,8 @@ package com.newpick4u.news.news.domain.repository;
 import com.newpick4u.news.news.domain.critria.NewsSearchCriteria;
 import com.newpick4u.news.news.domain.entity.News;
 import com.newpick4u.news.news.domain.model.Pagination;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,5 +12,8 @@ public interface NewsRepositoryCustom {
     Pagination<News> searchNewsList(NewsSearchCriteria request, boolean isMaster);
     Optional<News> findNewsByRole(UUID id, boolean isMaster);
     Optional<News> findWithTagsByAiNewsId(String aiNewsId);
+    List<News> findAllActive();
+    List<News> findLatestNews(int limit);
+    List<News> findByIds(List<UUID> ids);
 
 }

--- a/news/src/main/java/com/newpick4u/news/news/domain/repository/NewsRepositoryCustom.java
+++ b/news/src/main/java/com/newpick4u/news/news/domain/repository/NewsRepositoryCustom.java
@@ -1,6 +1,6 @@
 package com.newpick4u.news.news.domain.repository;
 
-import com.newpick4u.news.news.domain.critria.NewsSearchCriteria;
+import com.newpick4u.news.news.application.dto.NewsSearchCriteria;
 import com.newpick4u.news.news.domain.entity.News;
 import com.newpick4u.news.news.domain.model.Pagination;
 

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/jpa/NewsRepositoryCustomImpl.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/jpa/NewsRepositoryCustomImpl.java
@@ -131,4 +131,41 @@ public class NewsRepositoryCustomImpl implements NewsRepositoryCustom {
                         .fetchOne()
         );
     }
+
+    //추천알고리즘
+    @Override
+    public List<News> findAllActive() {
+        return queryFactory
+                .selectFrom(news)
+                .leftJoin(news.newsTagList, newsTag).fetchJoin()
+                .where(news.status.eq(NewsStatus.ACTIVE))
+                .distinct()
+                .fetch();
+    }
+
+    @Override
+    public List<News> findLatestNews(int limit) {
+        QNews news = QNews.news;
+
+        return queryFactory
+                .selectFrom(news)
+                .leftJoin(news.newsTagList, newsTag).fetchJoin()
+                .where(news.status.eq(NewsStatus.ACTIVE))
+                .orderBy(news.createdAt.desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public List<News> findByIds(List<UUID> ids) {
+        QNews news = QNews.news;
+        QNewsTag newsTag = QNewsTag.newsTag;
+
+        return queryFactory
+                .selectFrom(news)
+                .leftJoin(news.newsTagList, newsTag).fetchJoin()
+                .where(news.id.in(ids))
+                .distinct()
+                .fetch();
+    }
 }

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/jpa/NewsRepositoryCustomImpl.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/jpa/NewsRepositoryCustomImpl.java
@@ -1,6 +1,6 @@
 package com.newpick4u.news.news.infrastructure.jpa;
 
-import com.newpick4u.news.news.domain.critria.NewsSearchCriteria;
+import com.newpick4u.news.news.application.dto.NewsSearchCriteria;
 import com.newpick4u.news.news.domain.entity.News;
 import com.newpick4u.news.news.domain.entity.NewsStatus;
 import com.newpick4u.news.news.domain.entity.QNews;

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/jpa/NewsRepositoryCustomImpl.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/jpa/NewsRepositoryCustomImpl.java
@@ -22,8 +22,9 @@ import java.util.UUID;
 public class NewsRepositoryCustomImpl implements NewsRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
-    static QNews news;
-    static QNewsTag newsTag;
+    static final QNews news = QNews.news;
+    static final QNewsTag newsTag = QNewsTag.newsTag;
+
 
     // 복수조회
     @Override
@@ -120,9 +121,6 @@ public class NewsRepositoryCustomImpl implements NewsRepositoryCustom {
     // 테스트용 메서드
     @Override
     public Optional<News> findWithTagsByAiNewsId(String aiNewsId) {
-        QNews news = QNews.news;
-        QNewsTag newsTag = QNewsTag.newsTag;
-
         return Optional.ofNullable(
                 queryFactory
                         .selectFrom(news)
@@ -145,8 +143,6 @@ public class NewsRepositoryCustomImpl implements NewsRepositoryCustom {
 
     @Override
     public List<News> findLatestNews(int limit) {
-        QNews news = QNews.news;
-
         return queryFactory
                 .selectFrom(news)
                 .leftJoin(news.newsTagList, newsTag).fetchJoin()
@@ -158,9 +154,6 @@ public class NewsRepositoryCustomImpl implements NewsRepositoryCustom {
 
     @Override
     public List<News> findByIds(List<UUID> ids) {
-        QNews news = QNews.news;
-        QNewsTag newsTag = QNewsTag.newsTag;
-
         return queryFactory
                 .selectFrom(news)
                 .leftJoin(news.newsTagList, newsTag).fetchJoin()
@@ -168,4 +161,17 @@ public class NewsRepositoryCustomImpl implements NewsRepositoryCustom {
                 .distinct()
                 .fetch();
     }
+
+    // 테스트용
+    @Override
+    public Optional<News> findWithTagsById(UUID id) {
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(news)
+                        .leftJoin(news.newsTagList, newsTag).fetchJoin()
+                        .where(news.id.eq(id))
+                        .fetchOne()
+        );
+    }
+
 }

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/jpa/NewsRepositoryimpl.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/jpa/NewsRepositoryimpl.java
@@ -1,6 +1,6 @@
 package com.newpick4u.news.news.infrastructure.jpa;
 
-import com.newpick4u.news.news.domain.critria.NewsSearchCriteria;
+import com.newpick4u.news.news.application.dto.NewsSearchCriteria;
 import com.newpick4u.news.news.domain.entity.News;
 import com.newpick4u.news.news.domain.model.Pagination;
 import com.newpick4u.news.news.domain.repository.NewsRepository;

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/jpa/NewsRepositoryimpl.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/jpa/NewsRepositoryimpl.java
@@ -8,6 +8,7 @@ import com.newpick4u.news.news.domain.repository.NewsRepositoryCustom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -51,5 +52,20 @@ public class NewsRepositoryimpl implements NewsRepository {
     @Override
     public void flush() {
         newsJpaRepository.flush();
+    }
+
+    @Override
+    public List<News> findAllActive() {
+        return newsRepositoryCustom.findAllActive();
+    }
+
+    @Override
+    public List<News> findLatestNews(int limit) {
+        return newsRepositoryCustom.findLatestNews(limit);
+    }
+
+    @Override
+    public List<News> findByIds(List<UUID> ids)  {
+        return newsRepositoryCustom.findByIds(ids);
     }
 }

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/jpa/NewsRepositoryimpl.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/jpa/NewsRepositoryimpl.java
@@ -68,4 +68,21 @@ public class NewsRepositoryimpl implements NewsRepository {
     public List<News> findByIds(List<UUID> ids)  {
         return newsRepositoryCustom.findByIds(ids);
     }
+
+    @Override
+    public List<News> saveAll(List<News> newsList) {
+        return newsJpaRepository.saveAll(newsList);
+    }
+
+    @Override
+    public void deleteAll() {
+        newsJpaRepository.deleteAll();
+    }
+
+    @Override
+    public Optional<News> findById(UUID id) {
+        return newsJpaRepository.findById(id);
+    }
+
+
 }

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/redis/RedisConfig.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/redis/RedisConfig.java
@@ -3,16 +3,33 @@ package com.newpick4u.news.news.infrastructure.redis;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import org.springframework.beans.factory.annotation.Value;
+
 @Configuration
 public class RedisConfig {
 
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
     @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(); // localhost:6379
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(host);
+        config.setPort(port);
+        config.setPassword(RedisPassword.of(password)); // 🧨 요게 핵심
+        return new LettuceConnectionFactory(config);
     }
 
     @Bean

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/redis/RedisConfig.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/redis/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.newpick4u.news.news.infrastructure.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(); // localhost:6379
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/redis/RedissonConfig.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/redis/RedissonConfig.java
@@ -1,15 +1,37 @@
 package com.newpick4u.news.news.infrastructure.redis;
-
+import lombok.extern.slf4j.Slf4j;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@Slf4j
 public class RedissonConfig {
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private String port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
 
     @Bean
-    public RedissonClient redissonClient() {
-        return Redisson.create(); // application.yml에서 Redis 설정 자동 인식
+    public RedissonClient redissonClientFactory() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(REDISSON_HOST_PREFIX + host + ":" + port)
+                .setPassword(password);
+        return Redisson.create(config);
     }
+//    log.info(">>> REDIS_PASSWORD = " + password); // RedissonConfig.java 내부
+
 }
+

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/redis/RedissonConfig.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/redis/RedissonConfig.java
@@ -1,0 +1,15 @@
+package com.newpick4u.news.news.infrastructure.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Bean
+    public RedissonClient redissonClient() {
+        return Redisson.create(); // application.yml에서 Redis 설정 자동 인식
+    }
+}

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/redis/UserTagRedisOperator.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/redis/UserTagRedisOperator.java
@@ -1,0 +1,99 @@
+package com.newpick4u.news.news.infrastructure.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class UserTagRedisOperator {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final int MAX_TAGS = 50;
+    private static final Duration TAG_TTL = Duration.ofDays(30); // 30일간 미접속 시 태그 만료
+    private static final Duration RECOMMEND_CACHE_TTL = Duration.ofDays(1);
+    private static final String TAG_KEY_PATTERN = "user:*:tags";
+
+    // 태그 카운트 증가 (조회 시 호출)
+    public void incrementUserTags(Long userId, List<String> tagNames) {
+        String key = buildKey(userId);
+        for (String tag : tagNames) {
+            redisTemplate.opsForZSet().incrementScore(key, tag, 1);
+        }
+        trimTagLimit(key);
+        redisTemplate.expire(key, TAG_TTL);
+    }
+
+    // 유저 태그 점수 맵 가져오기
+    public Map<String, Double> getUserTagScoreMap(Long userId) {
+        String key = buildKey(userId);
+        Set<ZSetOperations.TypedTuple<String>> rawTags =
+                redisTemplate.opsForZSet().rangeWithScores(key, 0, -1);
+
+        if (rawTags == null) return Collections.emptyMap();
+
+        Map<String, Double> tagScoreMap = new HashMap<>();
+        for (ZSetOperations.TypedTuple<String> tuple : rawTags) {
+            if (tuple.getValue() != null && tuple.getScore() != null) {
+                tagScoreMap.put(tuple.getValue(), tuple.getScore());
+            }
+        }
+        return tagScoreMap;
+    }
+
+    // 태그 개수 제한 초과 시 오래된 태그 제거
+    private void trimTagLimit(String key) {
+        Long size = redisTemplate.opsForZSet().zCard(key);
+        if (size != null && size > MAX_TAGS) {
+            redisTemplate.opsForZSet().removeRange(key, 0, size - MAX_TAGS - 1);
+        }
+    }
+
+    private String buildKey(Long userId) {
+        return "user:" + userId + ":tags";
+    }
+
+    // 추천 캐시 키
+    private String recommendKey(Long userId) {
+        return "user:" + userId + ":recommend";
+    }
+
+    // 추천 뉴스 캐시 저장
+    public void cacheRecommendedNews(Long userId, List<String> newsIds) {
+        String key = recommendKey(userId);
+        redisTemplate.delete(key); // 덮어쓰기
+        redisTemplate.opsForList().rightPushAll(key, newsIds);
+        redisTemplate.expire(key, RECOMMEND_CACHE_TTL);
+    }
+
+    // 추천 뉴스 캐시 조회
+    public List<String> getCachedRecommendedNews(Long userId) {
+        String key = recommendKey(userId);
+        return redisTemplate.opsForList().range(key, 0, -1);
+    }
+
+    // 추천 캐시용 사용자 ID 목록 조회 (SCAN 기반)
+    public Set<Long> getAllUserIds() {
+        Set<String> keys = redisTemplate.keys(TAG_KEY_PATTERN);
+        if (keys == null || keys.isEmpty()) return Set.of();
+
+        return keys.stream()
+                .map(this::extractUserIdFromKey)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    private Long extractUserIdFromKey(String key) {
+        try {
+            String[] parts = key.split(":" );
+            return Long.parseLong(parts[1]);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/redis/UserTagRedisOperator.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/redis/UserTagRedisOperator.java
@@ -1,12 +1,17 @@
 package com.newpick4u.news.news.infrastructure.redis;
 
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Component
@@ -14,19 +19,39 @@ import java.util.stream.Collectors;
 public class UserTagRedisOperator {
 
     private final RedisTemplate<String, String> redisTemplate;
+    private final RedissonClient redissonClient;
+
     private static final int MAX_TAGS = 50;
     private static final Duration TAG_TTL = Duration.ofDays(30); // 30일간 미접속 시 태그 만료
     private static final Duration RECOMMEND_CACHE_TTL = Duration.ofDays(1);
+    private static final String LOCK_PREFIX = "lock:user:tags:";
     private static final String TAG_KEY_PATTERN = "user:*:tags";
 
-    // 태그 카운트 증가 (조회 시 호출)
+    // 태그 카운트 증가 (태그 기록 + 제한 개수 초과 시 삭제 + TTL 설정 (원자적 처리))
     public void incrementUserTags(Long userId, List<String> tagNames) {
         String key = buildKey(userId);
-        for (String tag : tagNames) {
-            redisTemplate.opsForZSet().incrementScore(key, tag, 1);
+        String lockKey = LOCK_PREFIX + userId;
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            if (lock.tryLock(3, 2, TimeUnit.SECONDS)) { // timeout: 대기 3초, 점유 2초
+                for (String tag : tagNames) {
+                    redisTemplate.opsForZSet().incrementScore(key, tag, 1);
+                }
+
+                trimTagLimit(key);
+                redisTemplate.expire(key, TAG_TTL);
+            } else {
+                throw new IllegalStateException("Redis 락 획득 실패: userId=" + userId);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Redis 락 인터럽트", e);
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
         }
-        trimTagLimit(key);
-        redisTemplate.expire(key, TAG_TTL);
     }
 
     // 유저 태그 점수 맵 가져오기
@@ -46,23 +71,6 @@ public class UserTagRedisOperator {
         return tagScoreMap;
     }
 
-    // 태그 개수 제한 초과 시 오래된 태그 제거
-    private void trimTagLimit(String key) {
-        Long size = redisTemplate.opsForZSet().zCard(key);
-        if (size != null && size > MAX_TAGS) {
-            redisTemplate.opsForZSet().removeRange(key, 0, size - MAX_TAGS - 1);
-        }
-    }
-
-    private String buildKey(Long userId) {
-        return "user:" + userId + ":tags";
-    }
-
-    // 추천 캐시 키
-    private String recommendKey(Long userId) {
-        return "user:" + userId + ":recommend";
-    }
-
     // 추천 뉴스 캐시 저장
     public void cacheRecommendedNews(Long userId, List<String> newsIds) {
         String key = recommendKey(userId);
@@ -79,13 +87,48 @@ public class UserTagRedisOperator {
 
     // 추천 캐시용 사용자 ID 목록 조회 (SCAN 기반)
     public Set<Long> getAllUserIds() {
-        Set<String> keys = redisTemplate.keys(TAG_KEY_PATTERN);
-        if (keys == null || keys.isEmpty()) return Set.of();
+        Set<Long> userIds = new HashSet<>();
+        ScanOptions scanOptions = ScanOptions.scanOptions().match(TAG_KEY_PATTERN).count(1000).build();
 
-        return keys.stream()
-                .map(this::extractUserIdFromKey)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
+        try (Cursor<byte[]> cursor = redisTemplate.getConnectionFactory()
+                .getConnection()
+                .scan(scanOptions)) {
+
+            while (cursor.hasNext()) {
+                String key = new String(cursor.next()); // byte[] → String
+                Long userId = extractUserIdFromKey(key);
+                if (userId != null) {
+                    userIds.add(userId);
+                }
+            }
+
+        } catch (Exception e) {
+            // 로그 처리 또는 예외 변환 처리
+            throw new RuntimeException("Redis SCAN 중 오류 발생", e);
+        }
+
+        return userIds;
+    }
+
+
+    // 내부메서드
+
+
+    // 태그 개수 제한 초과 시 오래된 태그 제거
+    private void trimTagLimit(String key) {
+        Long size = redisTemplate.opsForZSet().zCard(key);
+        if (size != null && size > MAX_TAGS) {
+            redisTemplate.opsForZSet().removeRange(key, 0, size - MAX_TAGS - 1);
+        }
+    }
+
+    private String buildKey(Long userId) {
+        return "user:" + userId + ":tags";
+    }
+
+    // 추천 캐시 키
+    private String recommendKey(Long userId) {
+        return "user:" + userId + ":recommend";
     }
 
     private Long extractUserIdFromKey(String key) {

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/util/NewsRecommender.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/util/NewsRecommender.java
@@ -1,12 +1,10 @@
 package com.newpick4u.news.news.infrastructure.util;
 
 import com.newpick4u.news.news.domain.entity.News;
-import com.newpick4u.news.news.domain.entity.UserTagLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/util/NewsRecommender.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/util/NewsRecommender.java
@@ -1,5 +1,7 @@
 package com.newpick4u.news.news.infrastructure.util;
 
+import com.newpick4u.news.news.application.usecase.NewsRecommenderProvider;
+import com.newpick4u.news.news.application.usecase.TagVectorConverterProvider;
 import com.newpick4u.news.news.domain.entity.News;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -8,9 +10,12 @@ import java.util.*;
 
 @Component
 @RequiredArgsConstructor
-public class NewsRecommender {
+public class NewsRecommender implements NewsRecommenderProvider {
 
-    public static List<News> recommendByContentVector(
+    private final TagVectorConverterProvider tagVectorConverterProvider;
+
+    @Override
+    public List<News> recommendByContentVector(
             double[] userVector,
             List<News> candidates,
             List<String> tagIndexList
@@ -20,7 +25,7 @@ public class NewsRecommender {
                         news,
                         VectorSimilarityCalculator.cosineSimilarity(
                                 userVector,
-                                TagVectorConverter.toNewsVector(news, tagIndexList)
+                                tagVectorConverterProvider.toNewsVector(news, tagIndexList)
                         )))
                 .sorted((a, b) -> Double.compare(b.getValue(), a.getValue())) // 유사도 내림차순
                 .limit(10)

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/util/NewsRecommender.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/util/NewsRecommender.java
@@ -1,0 +1,32 @@
+package com.newpick4u.news.news.infrastructure.util;
+
+import com.newpick4u.news.news.domain.entity.News;
+import com.newpick4u.news.news.domain.entity.UserTagLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class NewsRecommender {
+
+    public static List<News> recommendByContentVector(
+            double[] userVector,
+            List<News> candidates,
+            List<String> tagIndexList
+    ) {
+        return candidates.stream()
+                .map(news -> new AbstractMap.SimpleEntry<>(
+                        news,
+                        VectorSimilarityCalculator.cosineSimilarity(
+                                userVector,
+                                TagVectorConverter.toNewsVector(news, tagIndexList)
+                        )))
+                .sorted((a, b) -> Double.compare(b.getValue(), a.getValue())) // 유사도 내림차순
+                .limit(10)
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+}  

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/util/TagVectorConverter.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/util/TagVectorConverter.java
@@ -1,7 +1,6 @@
 package com.newpick4u.news.news.infrastructure.util;
 
 import com.newpick4u.news.news.domain.entity.News;
-import com.newpick4u.news.news.domain.entity.UserTagLog;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/util/TagVectorConverter.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/util/TagVectorConverter.java
@@ -1,0 +1,39 @@
+package com.newpick4u.news.news.infrastructure.util;
+
+import com.newpick4u.news.news.domain.entity.News;
+import com.newpick4u.news.news.domain.entity.UserTagLog;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class TagVectorConverter {
+    // 사용자 + 뉴스 태그로부터 전역 태그 셋 추출 (추천 벡터 인덱스용)
+    public static Set<String> extractGlobalTagSetFromNews(Map<String, Double> userTagMap, List<News> newsList) {
+        Set<String> tagSet = new HashSet<>(userTagMap.keySet());
+        for (News news : newsList) {
+            news.getNewsTagList().forEach(tag -> tagSet.add(tag.getName()));
+        }
+        return tagSet;
+    }
+
+    // 사용자 태그 점수 기반 벡터화
+    public static double[] toUserVector(Map<String, Double> tagScoreMap, List<String> tagIndexList) {
+        double[] vector = new double[tagIndexList.size()];
+        for (int i = 0; i < tagIndexList.size(); i++) {
+            vector[i] = tagScoreMap.getOrDefault(tagIndexList.get(i), 0.0);
+        }
+        return vector;
+    }
+
+    // 뉴스 태그 벡터화 (1 또는 0)
+    public static double[] toNewsVector(News news, List<String> tagIndexList) {
+        double[] vector = new double[tagIndexList.size()];
+        Set<String> tags = news.getNewsTagList().stream()
+                .map(tag -> tag.getName())
+                .collect(Collectors.toSet());
+        for (int i = 0; i < tagIndexList.size(); i++) {
+            vector[i] = tags.contains(tagIndexList.get(i)) ? 1.0 : 0.0;
+        }
+        return vector;
+    }
+}

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/util/TagVectorConverter.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/util/TagVectorConverter.java
@@ -1,13 +1,17 @@
 package com.newpick4u.news.news.infrastructure.util;
 
+import com.newpick4u.news.news.application.usecase.TagVectorConverterProvider;
 import com.newpick4u.news.news.domain.entity.News;
+import org.springframework.stereotype.Component;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class TagVectorConverter {
+@Component
+public class TagVectorConverter implements TagVectorConverterProvider {
     // 사용자 + 뉴스 태그로부터 전역 태그 셋 추출 (추천 벡터 인덱스용)
-    public static Set<String> extractGlobalTagSetFromNews(Map<String, Double> userTagMap, List<News> newsList) {
+    @Override
+    public Set<String> extractGlobalTagSetFromNews(Map<String, Double> userTagMap, List<News> newsList) {
         Set<String> tagSet = new HashSet<>(userTagMap.keySet());
         for (News news : newsList) {
             news.getNewsTagList().forEach(tag -> tagSet.add(tag.getName()));
@@ -16,7 +20,8 @@ public class TagVectorConverter {
     }
 
     // 사용자 태그 점수 기반 벡터화
-    public static double[] toUserVector(Map<String, Double> tagScoreMap, List<String> tagIndexList) {
+    @Override
+    public double[] toUserVector(Map<String, Double> tagScoreMap, List<String> tagIndexList) {
         double[] vector = new double[tagIndexList.size()];
         for (int i = 0; i < tagIndexList.size(); i++) {
             vector[i] = tagScoreMap.getOrDefault(tagIndexList.get(i), 0.0);
@@ -25,7 +30,8 @@ public class TagVectorConverter {
     }
 
     // 뉴스 태그 벡터화 (1 또는 0)
-    public static double[] toNewsVector(News news, List<String> tagIndexList) {
+    @Override
+    public double[] toNewsVector(News news, List<String> tagIndexList) {
         double[] vector = new double[tagIndexList.size()];
         Set<String> tags = news.getNewsTagList().stream()
                 .map(tag -> tag.getName())

--- a/news/src/main/java/com/newpick4u/news/news/infrastructure/util/VectorSimilarityCalculator.java
+++ b/news/src/main/java/com/newpick4u/news/news/infrastructure/util/VectorSimilarityCalculator.java
@@ -1,0 +1,27 @@
+package com.newpick4u.news.news.infrastructure.util;
+
+public class VectorSimilarityCalculator {
+
+    /**
+     * 코사인 유사도 계산
+     * 두 벡터 간의 코사인 유사도를 반환한다. (1에 가까울수록 유사)
+     */
+    public static double cosineSimilarity(double[] vec1, double[] vec2) {
+        if (vec1.length != vec2.length) {
+            throw new IllegalArgumentException("벡터 길이가 일치하지 않습니다.");
+        }
+
+        double dotProduct = 0.0;
+        double normVec1 = 0.0;
+        double normVec2 = 0.0;
+
+        for (int i = 0; i < vec1.length; i++) {
+            dotProduct += vec1[i] * vec2[i];
+            normVec1 += vec1[i] * vec1[i];
+            normVec2 += vec2[i] * vec2[i];
+        }
+
+        double denominator = Math.sqrt(normVec1) * Math.sqrt(normVec2);
+        return denominator == 0.0 ? 0.0 : dotProduct / denominator;
+    }
+}

--- a/news/src/main/java/com/newpick4u/news/news/presentation/NewsAPIController.java
+++ b/news/src/main/java/com/newpick4u/news/news/presentation/NewsAPIController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -50,5 +51,14 @@ public class NewsAPIController {
             @CurrentUserInfo @Parameter(hidden = true) CurrentUserInfoDto userInfoDto
     ) {
         return ResponseEntity.ok(newsService.searchNewsList(request, userInfoDto));
+    }
+
+    @GetMapping("/recommend")
+    @Operation(summary = "추천 뉴스 리스트 조회", description = "10개의 추천 뉴스를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "뉴스 추천 리스트 조회 성공")
+    public List<NewsSummaryDto> recommend(
+            @CurrentUserInfo @Parameter(hidden = true) CurrentUserInfoDto currentUser
+    ) {
+        return newsService.recommendTop10(currentUser);
     }
 }

--- a/news/src/main/java/com/newpick4u/news/news/presentation/NewsAPIController.java
+++ b/news/src/main/java/com/newpick4u/news/news/presentation/NewsAPIController.java
@@ -9,7 +9,7 @@ import com.newpick4u.news.news.application.usecase.NewsService;
 import com.newpick4u.news.news.domain.critria.NewsSearchCriteria;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import com.newpick4u.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -28,17 +28,17 @@ public class NewsAPIController {
 
     @GetMapping("/{id}")
     @Operation(summary = "뉴스 조회", description = "특정 뉴스를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "뉴스 조회 성공")
-    public ResponseEntity<NewsResponseDto> getNews(
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "뉴스 조회 성공")
+    public ResponseEntity<ApiResponse<NewsResponseDto>> getNews(
             @PathVariable UUID id,
             @CurrentUserInfo @Parameter(hidden = true) CurrentUserInfoDto userInfoDto
     ) {
-        return ResponseEntity.ok(newsService.getNews(id, userInfoDto));
+        return ResponseEntity.ok(ApiResponse.ok(newsService.getNews(id, userInfoDto)));
     }
 
     @GetMapping
     @Operation(summary = "뉴스 리스트 조회", description = "뉴스 리스트를 검색 및 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "뉴스 리스트 조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "뉴스 리스트 조회 성공")
     @Parameters({
             @Parameter(name = "keyword", description = "검색 키워드"),
             @Parameter(name = "filter", description = "필터 조건 (e.g., title, tag)"),
@@ -46,19 +46,19 @@ public class NewsAPIController {
             @Parameter(name = "page", description = "페이지 번호"),
             @Parameter(name = "size", description = "페이지 사이즈")
     })
-    public ResponseEntity<PageResponse<NewsSummaryDto>> searchNewsList(
+    public ResponseEntity<ApiResponse<PageResponse<NewsSummaryDto>>> searchNewsList(
             @ModelAttribute NewsSearchCriteria request,
             @CurrentUserInfo @Parameter(hidden = true) CurrentUserInfoDto userInfoDto
     ) {
-        return ResponseEntity.ok(newsService.searchNewsList(request, userInfoDto));
+        return ResponseEntity.ok(ApiResponse.ok(newsService.searchNewsList(request, userInfoDto)));
     }
 
     @GetMapping("/recommend")
     @Operation(summary = "추천 뉴스 리스트 조회", description = "10개의 추천 뉴스를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "뉴스 추천 리스트 조회 성공")
-    public List<NewsSummaryDto> recommend(
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "뉴스 추천 리스트 조회 성공")
+    public ResponseEntity<ApiResponse<List<NewsSummaryDto>>> recommend(
             @CurrentUserInfo @Parameter(hidden = true) CurrentUserInfoDto currentUser
     ) {
-        return newsService.recommendTop10(currentUser);
+        return ResponseEntity.ok(ApiResponse.ok(newsService.recommendTop10(currentUser)));
     }
 }

--- a/news/src/main/java/com/newpick4u/news/news/presentation/NewsAPIController.java
+++ b/news/src/main/java/com/newpick4u/news/news/presentation/NewsAPIController.java
@@ -6,7 +6,7 @@ import com.newpick4u.news.news.application.dto.response.NewsResponseDto;
 import com.newpick4u.news.news.application.dto.response.NewsSummaryDto;
 import com.newpick4u.news.news.application.dto.response.PageResponse;
 import com.newpick4u.news.news.application.usecase.NewsService;
-import com.newpick4u.news.news.domain.critria.NewsSearchCriteria;
+import com.newpick4u.news.news.application.dto.NewsSearchCriteria;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameters;
 import com.newpick4u.common.response.ApiResponse;

--- a/news/src/main/java/com/newpick4u/news/news/presentation/NewsInternalController.java
+++ b/news/src/main/java/com/newpick4u/news/news/presentation/NewsInternalController.java
@@ -6,8 +6,8 @@ import com.newpick4u.news.news.application.dto.response.NewsResponseDto;
 import com.newpick4u.news.news.application.usecase.NewsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import com.newpick4u.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,11 +26,11 @@ public class NewsInternalController {
 
     @GetMapping("/{id}")
     @Operation(summary = "뉴스 조회", description = "특정 뉴스를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "뉴스 조회 성공")
-    public ResponseEntity<NewsResponseDto> getNews(
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "뉴스 조회 성공")
+    public ResponseEntity<ApiResponse<NewsResponseDto>> getNews(
             @PathVariable UUID id,
             @CurrentUserInfo @Parameter(hidden = true) CurrentUserInfoDto userInfoDto
     ) {
-        return ResponseEntity.ok(newsService.getNews(id, userInfoDto));
+        return ResponseEntity.ok(ApiResponse.ok(newsService.getNews(id, userInfoDto)));
     }
 }

--- a/news/src/main/java/com/newpick4u/news/news/presentation/NewsInternalController.java
+++ b/news/src/main/java/com/newpick4u/news/news/presentation/NewsInternalController.java
@@ -1,0 +1,36 @@
+package com.newpick4u.news.news.presentation;
+
+import com.newpick4u.common.resolver.annotation.CurrentUserInfo;
+import com.newpick4u.common.resolver.dto.CurrentUserInfoDto;
+import com.newpick4u.news.news.application.dto.response.NewsResponseDto;
+import com.newpick4u.news.news.application.usecase.NewsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/internal/v1/news")
+@RequiredArgsConstructor
+@Tag(name = "뉴스 INTERNAL", description = "뉴스 INTERNAL")
+public class NewsInternalController {
+    private final NewsService newsService;
+
+    @GetMapping("/{id}")
+    @Operation(summary = "뉴스 조회", description = "특정 뉴스를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "뉴스 조회 성공")
+    public ResponseEntity<NewsResponseDto> getNews(
+            @PathVariable UUID id,
+            @CurrentUserInfo @Parameter(hidden = true) CurrentUserInfoDto userInfoDto
+    ) {
+        return ResponseEntity.ok(newsService.getNews(id, userInfoDto));
+    }
+}

--- a/news/src/main/resources/application-develop.yml
+++ b/news/src/main/resources/application-develop.yml
@@ -1,11 +1,6 @@
 server:
   port: 11001
 
-#eureka:
-#  client:
-#    enabled: false
-
-
 spring:
   application:
     name: news-service
@@ -46,6 +41,7 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
 
 springdoc:
   api-docs:

--- a/news/src/main/resources/application-develop.yml
+++ b/news/src/main/resources/application-develop.yml
@@ -5,7 +5,10 @@ server:
 #  client:
 #    enabled: false
 
+
 spring:
+  application:
+    name: news-service
   config:
     import:
       - file:.env.news[.properties]
@@ -38,6 +41,11 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
         default_batch_fetch_size: 100
         format_sql: true
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 springdoc:
   api-docs:

--- a/news/src/test/java/com/newpick4u/news/NewsInfoConsumerTest.java
+++ b/news/src/test/java/com/newpick4u/news/NewsInfoConsumerTest.java
@@ -5,8 +5,6 @@ import com.newpick4u.news.news.application.dto.NewsInfoDto;
 import com.newpick4u.news.news.domain.entity.News;
 import com.newpick4u.news.news.domain.entity.NewsStatus;
 import com.newpick4u.news.news.domain.repository.NewsRepository;
-import com.newpick4u.news.news.infrastructure.kafka.KafkaConfig;
-import com.newpick4u.news.news.infrastructure.kafka.NewsInfoConsumer;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -16,7 +14,6 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
@@ -32,15 +29,10 @@ import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
-
-@SpringBootTest(properties = {
-        "eureka.client.enabled=false"
-})
+@SpringBootTest
 @ActiveProfiles("test")
 @EmbeddedKafka(partitions = 1, topics = {"news-info.fct.v1", "news-info-dlq.fct.v1"})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD) // 이게 있으면 상태가 초기화됩니다
-@Import({KafkaConfig.class, NewsInfoConsumer.class})
 class NewsInfoConsumerTest {
 
     @Autowired

--- a/news/src/test/java/com/newpick4u/news/NewsRecommendationTest.java
+++ b/news/src/test/java/com/newpick4u/news/NewsRecommendationTest.java
@@ -1,0 +1,170 @@
+package com.newpick4u.news;
+
+import static org.assertj.core.api.Assertions.within;
+import com.newpick4u.common.resolver.dto.CurrentUserInfoDto;
+import com.newpick4u.common.resolver.dto.UserRole;
+import com.newpick4u.news.news.application.dto.response.NewsSummaryDto;
+import com.newpick4u.news.news.application.usecase.NewsService;
+import com.newpick4u.news.news.domain.entity.News;
+import com.newpick4u.news.news.domain.entity.NewsTag;
+import com.newpick4u.news.news.domain.repository.NewsRepository;
+import com.newpick4u.news.news.domain.repository.NewsRepositoryCustom;
+import com.newpick4u.news.news.infrastructure.redis.RedisConfig;
+import com.newpick4u.news.news.infrastructure.redis.RedissonConfig;
+import com.newpick4u.news.news.infrastructure.redis.UserTagRedisOperator;
+import com.newpick4u.news.news.infrastructure.util.NewsRecommender;
+import com.newpick4u.news.news.infrastructure.util.VectorSimilarityCalculator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "spring.data.redis.host=localhost",
+        "spring.data.redis.port=6379",
+        "spring.data.redis.password=systempass"
+})
+//
+//@TestPropertySource(properties = "spring.config.import=")
+//@ImportAutoConfiguration(exclude = {RedisConfig.class, RedissonConfig.class })
+class NewsRecommendationTest {
+
+    @Autowired
+    NewsRepository newsRepository;
+
+    @Autowired
+    UserTagRedisOperator userTagRedisOperator;
+
+    @Autowired
+    NewsService newsService;
+
+    @Autowired
+    NewsRepositoryCustom newsRepositoryCustom;
+
+    @Autowired
+    NewsRecommender newsRecommender;
+
+    @Autowired
+    RedisTemplate<String, String> redisTemplate;
+
+    @BeforeEach
+    void setUp() {
+        newsRepository.deleteAll(); // 깨끗한 상태 유지
+        redisTemplate.getConnectionFactory().getConnection().flushDb(); // Redis 초기화
+    }
+
+    @Test
+    void 전체_흐름_및_추천결과_검증() {
+        // 1. 뉴스 50개 생성 및 저장
+        List<String> tagsPool = IntStream.range(0, 30).mapToObj(i -> "tag" + i).toList();
+        List<News> newsList = IntStream.range(0, 50)
+            .mapToObj(i -> {
+                News news = News.create("ai-news-" + i, "title" + i, "content", "url", "2023", 0L);
+                List<NewsTag> tagList = IntStream.range(0, 3)
+                    .mapToObj(j -> NewsTag.create(UUID.randomUUID(), tagsPool.get((i + j) % tagsPool.size()), news))
+                    .toList();
+                news.addTags(tagList);
+                return news;
+            }).toList();
+        newsRepository.saveAll(newsList);
+
+        // 2. 관심 태그 기록
+        Long userId = 123L;
+        List<String> interestedTags = tagsPool.subList(0, 20);
+        userTagRedisOperator.incrementUserTags(userId, interestedTags);
+
+        // 3. 추천 호출
+        CurrentUserInfoDto user = new CurrentUserInfoDto(userId, UserRole.ROLE_USER);
+        List<NewsSummaryDto> recommended = newsService.recommendTop10(user);
+
+        // 4. 추천 결과 10개인지 검증
+        assertThat(recommended).hasSize(10);
+
+        // ✅ 5. 유사도가 높은 뉴스가 먼저 오는지 (간접검증: 태그 포함 개수 체크)
+        List<String> userTags = new ArrayList<>(interestedTags);
+        for (NewsSummaryDto dto : recommended) {
+            News news = newsRepositoryCustom.findWithTagsById(dto.id())
+                    .orElseThrow();
+
+            long matchedTags = news.getNewsTagList().stream()
+                .map(NewsTag::getName)
+                .filter(userTags::contains)
+                .count();
+            assertThat(matchedTags).isGreaterThan(0);
+        }
+    }
+
+    @Test
+    void 캐시_적용_결과_검증() {
+        Long userId = 456L;
+        List<String> tagList = List.of("tag1", "tag2", "tag3");
+        userTagRedisOperator.incrementUserTags(userId, tagList);
+
+        // 실제 뉴스 10개 저장
+        List<News> newsList = IntStream.range(0, 10)
+                .mapToObj(i -> {
+                    News news = News.create("ai-news-cached-" + i, "title" + i, "content", "url", "2023", 0L);
+                    List<NewsTag> tags = tagList.stream()
+                            .map(tag -> NewsTag.create(UUID.randomUUID(), tag, news))
+                            .toList();
+                    news.addTags(tags);
+                    return news;
+                })
+                .toList();
+        newsRepository.saveAll(newsList);
+
+        // 캐시 저장 (실제 저장된 UUID 기반)
+        List<String> savedNewsIds = newsList.stream()
+                .map(n -> n.getId().toString())
+                .toList();
+        userTagRedisOperator.cacheRecommendedNews(userId, savedNewsIds);
+
+        // 2. recommendTop10 호출 시 캐시 사용되는지 검증
+        CurrentUserInfoDto user = new CurrentUserInfoDto(userId, UserRole.ROLE_USER);
+        List<NewsSummaryDto> recommended = newsService.recommendTop10(user);
+
+        assertThat(recommended).hasSize(10);
+        assertThat(recommended).allMatch(dto -> savedNewsIds.contains(dto.id().toString()));
+    }
+
+    @Test
+    void 태그_50개_초과시_정상_제한되는지() {
+        Long userId = 789L;
+        List<String> manyTags = IntStream.range(0, 100).mapToObj(i -> "tag" + i).toList();
+
+        userTagRedisOperator.incrementUserTags(userId, manyTags);
+
+        Map<String, Double> tagScoreMap = userTagRedisOperator.getUserTagScoreMap(userId);
+
+        assertThat(tagScoreMap).hasSizeLessThanOrEqualTo(50); // ✅ 최대 50개 제한 확인
+    }
+
+    @Test
+    void 코사인_유사도_정확성_테스트() {
+        double[] vec1 = {1, 0, 1};
+        double[] vec2 = {1, 1, 1};
+        double[] vec3 = {0, 1, 0};
+
+        double sim12 = VectorSimilarityCalculator.cosineSimilarity(vec1, vec2);
+        double sim13 = VectorSimilarityCalculator.cosineSimilarity(vec1, vec3);
+
+        assertThat(sim12).isGreaterThan(sim13); // ✅ vec1과 vec2가 더 유사함
+        assertThat(sim12).isCloseTo(0.816, within(0.01));
+    }
+}

--- a/news/src/test/java/com/newpick4u/news/NewsTagConsumerTest.java
+++ b/news/src/test/java/com/newpick4u/news/NewsTagConsumerTest.java
@@ -1,16 +1,12 @@
 package com.newpick4u.news;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.newpick4u.news.news.application.dto.NewsInfoDto;
 import com.newpick4u.news.news.application.dto.NewsTagDto;
 import com.newpick4u.news.news.application.dto.NewsTagDto.TagDto;
 import com.newpick4u.news.news.domain.entity.News;
 import com.newpick4u.news.news.domain.entity.TagInbox;
 import com.newpick4u.news.news.domain.repository.NewsRepository;
 import com.newpick4u.news.news.domain.repository.TagInboxRepository;
-import com.newpick4u.news.news.infrastructure.kafka.KafkaConfig;
-import com.newpick4u.news.news.infrastructure.kafka.NewsInfoConsumer;
-import com.newpick4u.news.news.infrastructure.kafka.NewsTagConsumer;
 import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -18,7 +14,6 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
@@ -26,7 +21,6 @@ import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.*;
@@ -36,13 +30,10 @@ import java.util.stream.StreamSupport;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-@SpringBootTest(properties = {
-        "eureka.client.enabled=false"
-})
+@SpringBootTest
 @ActiveProfiles("test")
 @EmbeddedKafka(partitions = 1, topics = {"tag.fct.v1", "tag-dlq.fct.v1"})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD) // 이게 있으면 상태가 초기화됩니다
-@Import({KafkaConfig.class, NewsTagConsumer.class})
 class NewsTagConsumerTest {
 
     @Autowired

--- a/news/src/test/java/com/newpick4u/news/TagInboxSchedulerTest.java
+++ b/news/src/test/java/com/newpick4u/news/TagInboxSchedulerTest.java
@@ -11,16 +11,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.UUID;
 
-@SpringBootTest(properties = {
-        "eureka.client.enabled=false"
-})
+@SpringBootTest
 @ActiveProfiles("test")
 class TagInboxSchedulerTest {
     @Autowired

--- a/news/src/test/resources/application-test.yml
+++ b/news/src/test/resources/application-test.yml
@@ -2,6 +2,8 @@ server:
   port: 11001
 
 spring:
+  application:
+    name: news-service
   config:
     import:
       - file:.env.news[.properties]
@@ -28,3 +30,9 @@ spring:
       hibernate:
       dialect: org.hibernate.dialect.MySQL8Dialect
       format_sql: true
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}


### PR DESCRIPTION
## Description


Resolves: #52

### 흐름
1. 사용자 뉴스 조회 → 관심 태그 Redis에 기록 (ZSet, TTL 30일)
2. 매일 새벽 3시 → 배치 스케줄러가 전체 사용자에 대해 추천 계산
   2-1. 사용자별 관심 태그 → 벡터화
   2-2. 전체 뉴스 벡터와 코사인 유사도 비교
   2-3. 상위 10개 뉴스 UUID만 Redis List에 캐시
3. 사용자가 추천 요청 → Redis 캐시에서 추천 뉴스 ID 조회
   3-1. 없으면 최신 뉴스 10개 Fallback

### 추천 방식 원리
벡터 기반 Content-Based Filtering
사용자 벡터: Map<String, Double> → 관심 태그를 기준으로 만든 점수 기반 벡터
뉴스 벡터: List<News> → 각 뉴스의 태그 유무로 1/0으로 벡터화
유사도 계산: 코사인 유사도를 통해 사용자가 관심 가질 만한 뉴스를 유사도 기준으로 추림
유사도가 1에 가까울수록 추천 우선순위 ↑

### 고려한 점
1. 추천 연산 실시간 X → 배치 처리 (스케줄링)
- 매일 새벽 3시 한 번만 전체 유저 추천 계산
- 사용자는 계산 결과만 Redis에서 빠르게 조회
- 연산 시점과 응답 시점 분리
2. 스레드 풀(ExecutorService) 사용
- Executors.newFixedThreadPool(10) 으로 병렬 처리
- 사용자별 추천 작업을 동시에 수행하되 10개 스레드 제한
- 과도한 스레드 생성 방지, CPU/메모리 보호
3. Redis 캐시 활용
- 추천 결과는 Redis에 1일 TTL로 캐싱
- 실시간 계산 없이 조회만으로 응답 가능
- DB 커넥션 낭비 없이 빠른 조회 처리
- Read 부하를 완전히 Redis로 위임
4. 태그 데이터 제한 + 자동 정리
- 사용자 관심 태그는 최대 50개까지만 유지
- 초과 시 오래된 태그부터 제거 (ZSet removeRange)
- Redis ZSet 메모리 사용 제어
5. TTL 설정으로 휴먼 유저 정리
- 30일간 미접속한 유저의 태그 데이터 자동 만료 (expire)
- 사용하지 않는 캐시 데이터 제거

## PR Type
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
